### PR TITLE
Suggested changes to avoid funnel breaks

### DIFF
--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -469,6 +469,7 @@ var VGS = VGS || {
                      *
                      * @event auth.visitor
                      */
+                    response.visitor.status = "1";
                     VGS.Event.fire('auth.visitor', response.visitor);
                 }
                 VGS.Auth.valid = response.result;
@@ -480,6 +481,15 @@ var VGS = VGS || {
                     VGS.log('-- invalid session, do not allow login', 'log');
                     VGS.Auth.setSession(null, 'unknown');
                 }
+            } else if (typeof (response.visitor) !== 'undefined') {
+                /**
+                * Fired when the visitor is in a SPID session but has not acccepted the product agreement.
+                *
+                * @event auth.visitor
+                 */
+                response.visitor.status = "2";
+                VGS.Event.fire('auth.visitor', response.visitor);
+                
             } else if (response.error && response.response) {
                 if (typeof (response.response.visitor) !== 'undefined') {
                     /**
@@ -487,6 +497,7 @@ var VGS = VGS || {
                      *
                      * @event auth.visitor
                      */
+                    response.response.visitor.status = "3"; 
                     VGS.Event.fire('auth.visitor', response.response.visitor);
                 }
                 // There is an error and a response indicating the session status

--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -469,7 +469,7 @@ var VGS = VGS || {
                      *
                      * @event auth.visitor
                      */
-                    response.visitor.status = "1";
+                    response.visitor.status = "Logged in";
                     VGS.Event.fire('auth.visitor', response.visitor);
                 }
                 VGS.Auth.valid = response.result;
@@ -487,7 +487,7 @@ var VGS = VGS || {
                 *
                 * @event auth.visitor
                  */
-                response.visitor.status = "2";
+                response.visitor.status = "SPiD user";
                 VGS.Event.fire('auth.visitor', response.visitor);
                 
             } else if (response.error && response.response) {
@@ -497,7 +497,7 @@ var VGS = VGS || {
                      *
                      * @event auth.visitor
                      */
-                    response.response.visitor.status = "3"; 
+                    response.response.visitor.status = "Not logged in"; 
                     VGS.Event.fire('auth.visitor', response.response.visitor);
                 }
                 // There is an error and a response indicating the session status


### PR DESCRIPTION
In the case where a user has an active SPiD session, but has not accepted the product agreement, the SPiD SDK will never return the anonymous tracking uid used by Mixpanel. This is because the SDK never fires the "auth.visitor" event even though the data was received from SPiD. The tracking Id is returned if the user has no SPiD session at all, so it should also be fired in the case above.  

Beause of the problem above, Mixpanel creates its own tracking id. This causes funnel breaks on a big portion of the traffic as soon as they visit a SPiD page.

I have also added a SPiD status variable for convenience. It is really useful to know what kind of conversion funnel the user must follow to convert. Right now we do not have a way of segment conversion rates for no SPiD users, SPiD users that has not accepted the agreement, logged in users etc.