### PR TITLE
Add local storage as an alternative to saving session data in a cookie

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,8 @@ module.exports = function(grunt) {
           'src/spid-talk.js',
           'src/spid-cookie.js',
           'src/spid-cache.js',
+          'src/spid-localstorage.js',
+          'src/spid-persist.js',
           'src/spid-uri.js',
           'src/spid-event.js',
           'src/spid-event-trigger.js'

--- a/examples/logincheck/index.html
+++ b/examples/logincheck/index.html
@@ -6,22 +6,22 @@
 </head>
 <body>
 	<div id="content"></div>
-	<script type="text/javascript" src="../../dist/spid-sdk-1.7.3.js"></script>
+	<script type="text/javascript" src="../../dist/spid-sdk-2.0.0.js"></script>
 	<script type="text/javascript">
 		try {
 			function getLoggedInUser(response) {
-				VGS.log(response);
+				SPID.Log.info(response);
 				if (typeof (response.session) === 'object' && response.status === 'connected') {
 					// logged in and connected user
-					$("#content").html('Logged in as <a href="'+VGS.getAccountURI()+'">'+response.session.displayName+'</a> | <a href="javascript:;" onclick="VGS.Auth.logout();">Logg ut</a>');
+					$("#content").html('Logged in as <a href="'+ SPiD.Uri.account()  +'">'+response.session.displayName+'</a> | <a href="javascript:;" onclick="SPiD.logout();">Logg ut</a>');
 				} else {
 					// No valid session found
-					$("#content").html('<a href="' + VGS.getLoginURI() + '">Login</a> | <a href="' + VGS.getSignupURI() + '">Sign up</a>');
+					$("#content").html('<a href="' + SPiD.Uri.login() + '">Login</a> | <a href="' + SPiD.Uri.signup()+ '">Sign up</a>');
 				}
 			}
 			$(document).ready(function() {
 				//Listen to auth.sessionChange event
-				VGS.Event.subscribe('auth.sessionChange', function(data) { VGS.log('sessionChange'); getLoggedInUser(data); });
+				SPiD.Event.subscribe('SPiD.sessionChange', function(data) { SPiD.Log.info('sessionChange'); getLoggedInUser(data); });
 				/*
 				Or listen to specific event
 				VGS.Event.subscribe('auth.login', function(data) { VGS.log('login'); getLoggedInUser(data); });
@@ -32,9 +32,19 @@
 				VGS.Event.subscribe('auth.statusChange', function(data) { VGS.log('statusChange'); getLoggedInUser(data); });
 				*/
 				//Listen to VGS.error message, to set login/register button if something goes wrong
-				VGS.Event.subscribe('VGS.error', function(data) { getLoggedInUser(data); });
-				VGS.init({client_id: '4d00e8d6bf92fc8648000000', server: 'stage.payment.schibsted.se', prod:false, logging:true});
-			});
+				SPiD.Event.subscribe('SPiD.error', function(data) {
+                    getLoggedInUser(data);
+                });
+
+                SPiD.init({client_id: '4d00e8d6bf92fc8648000000', server: 'stage.payment.schibsted.se', prod:false, logging:true});
+
+                SPiD.hasSession(function(err, data) {
+                    SPID.Log.info("Wow ",err);
+                    SPID.Log.info("Such data ",data);
+                });
+
+
+            });
 		} catch (error) {
 			alert(error);
 		}

--- a/examples/logincheck/index.html
+++ b/examples/logincheck/index.html
@@ -10,7 +10,7 @@
 	<script type="text/javascript">
 		try {
 			function getLoggedInUser(response) {
-				SPID.Log.info(response);
+				SPiD.Log.info(response);
 				if (typeof (response.session) === 'object' && response.status === 'connected') {
 					// logged in and connected user
 					$("#content").html('Logged in as <a href="'+ SPiD.Uri.account()  +'">'+response.session.displayName+'</a> | <a href="javascript:;" onclick="SPiD.logout();">Logg ut</a>');
@@ -36,11 +36,11 @@
                     getLoggedInUser(data);
                 });
 
-                SPiD.init({client_id: '4d00e8d6bf92fc8648000000', server: 'stage.payment.schibsted.se', prod:false, logging:true});
+                SPiD.init({client_id: '4d00e8d6bf92fc8648000000', server: 'identity-pre.schibsted.com', logging:true});
 
                 SPiD.hasSession(function(err, data) {
-                    SPID.Log.info("Wow ",err);
-                    SPID.Log.info("Such data ",data);
+                    SPiD.Log.info("Wow ",err);
+                    SPiD.Log.info("Such data ",data);
                 });
 
 

--- a/src/spid-cache.js
+++ b/src/spid-cache.js
@@ -12,27 +12,17 @@
     }
 
     function set(key, value) {
-        if(enabled()) {
-            _storage[key] = encode(value);
-        }
+        _storage[key] = encode(value);
     }
 
     function get(key) {
-        if(enabled()) {
-            return _storage[key] ? decode(_storage[key]) : null;
-        }
+        return _storage[key] ? decode(_storage[key]) : null;
     }
 
     function clear(key) {
-        if(enabled() && _storage[key]) {
+        if(_storage[key]) {
             _storage[key] = null;
         }
-    }
-
-    function enabled() {
-        var options = exports.options();
-        //Double negative to force boolean
-        return !!options.cache;
     }
 
     exports.Cache = {
@@ -40,8 +30,7 @@
         encode: encode,
         set: set,
         get: get,
-        clear: clear,
-        enabled: enabled
+        clear: clear
     };
 
 }(SPiD));

--- a/src/spid-cookie.js
+++ b/src/spid-cookie.js
@@ -55,12 +55,6 @@
         return 'spid_js_' + (options.prod ? '' : 'test_') + options.client_id;
     }
 
-    function enabled() {
-        var options = exports.options();
-        //Double negative to force boolean
-        return !!options.cookie;
-    }
-
     function _setRaw(name, value, expiresIn, domain) {
 
         var date = new Date();
@@ -80,7 +74,6 @@
         set: set,
         get: get,
         clear: clear,
-        name: name,
-        enabled: enabled
+        name: name
     };
 }(SPiD));

--- a/src/spid-localstorage.js
+++ b/src/spid-localstorage.js
@@ -1,0 +1,52 @@
+/*global SPiD:false*/
+;
+(function(exports) {
+
+    var logger = exports.Log,
+        keyPrefix = "SPID_",
+        enabled = true;
+
+    function decode(value) {
+        return JSON.parse(value);
+    }
+
+    function encode(value) {
+        return JSON.stringify(value);
+    }
+
+    function _toKey(key) {
+        return keyPrefix + key;
+    }
+
+    function get(key) {
+        try {
+            return decode(window.localStorage.getItem(_toKey(key)));
+        } catch(e) {
+            logger.info(e);
+        }
+        return null;
+    }
+
+    function set(key, value) {
+        try {
+            window.localStorage.setItem(_toKey(key), encode(value));
+        } catch(e) {
+            logger.info(e);
+        }
+    }
+
+    function clear(key) {
+        try {
+            window.localStorage.setItem(_toKey(key), null);
+        } catch(e) {
+            logger.info(e);
+        }
+    }
+
+    exports.LocalStorage = {
+        set: set,
+        get: get,
+        clear: clear,
+        enabled: enabled
+    };
+}(SPiD));

--- a/src/spid-localstorage.js
+++ b/src/spid-localstorage.js
@@ -1,6 +1,5 @@
 /*global SPiD:false*/
-;
-(function(exports) {
+;(function(exports) {
 
     var logger = exports.Log,
         keyPrefix = "SPID_",

--- a/src/spid-persist.js
+++ b/src/spid-persist.js
@@ -18,8 +18,8 @@
         get: function(key) {
             getPersistenceModule().get(key);
         },
-        set: function(key, value) {
-            getPersistenceModule().set(key, value);
+        set: function(key, value, expiresIn) {
+            getPersistenceModule().set(key, value, expiresIn);
         },
         clear: function(key) {
             getPersistenceModule().clear(key);

--- a/src/spid-persist.js
+++ b/src/spid-persist.js
@@ -1,0 +1,30 @@
+/*global SPiD:false*/
+;
+(function(exports) {
+
+    var noop = function() {
+    };
+
+    function getPersistenceModule() {
+        var storages = {
+            localstorage: exports.LocalStorage,
+            cookie: exports.Cookie,
+            cache: exports.Cache,
+            standard: {get: noop, set: noop, clear: noop}
+        };
+        return storages[(exports.options().storage || 'standard')];
+    }
+
+    exports.Persist = {
+        get: function(key) {
+            getPersistenceModule().get(key);
+        },
+        set: function(key, value) {
+            getPersistenceModule().set(key, value);
+        },
+        clear: function(key) {
+            getPersistenceModule().clear(key);
+        }
+    };
+
+}(SPiD));

--- a/src/spid-persist.js
+++ b/src/spid-persist.js
@@ -1,6 +1,5 @@
 /*global SPiD:false*/
-;
-(function(exports) {
+;(function(exports) {
 
     var noop = function() {
     };

--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -46,7 +46,7 @@
             },
             handleResponse = function(err, data) {
                 if(that.Persist && !err && !!data.result) {
-                    that.Persist.set("Session", data);
+                    that.Persist.set("Session", data, data.expiresIn);
                 }
                 respond(err, data);
             },

--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -9,8 +9,7 @@
             logging: false,
             prod: true,
             https: true,
-            cookie: true,
-            cache: true,
+            storage: 'localstorage',
             timeout: 15000,
             refresh_timeout: 900000,
             varnish_expiration: null
@@ -46,8 +45,8 @@
                 callback(err, data);
             },
             handleResponse = function(err, data) {
-                if(that.Cookie && that.Cookie.enabled() && !err && !!data.result) {
-                    that.Cookie.set(data);
+                if(that.Persist && !err && !!data.result) {
+                    that.Persist.set("Session", data);
                 }
                 respond(err, data);
             },
@@ -59,8 +58,8 @@
                 handleResponse(err, data);
             };
 
-        if(this.Cookie && this.Cookie.enabled()) {
-            var data = this.Cookie.get();
+        if(this.Persist) {
+            var data = this.Persist.get("Session");
             if(data) {
                 _session = data;
                 return respond(null, data);
@@ -70,7 +69,7 @@
     }
 
     function hasProduct(productId, callback) {
-        var cache = this.Cache && this.Cache.enabled() ? this.Cache : null,
+        var cache = this.Persist,
             util = this.Util;
         callback = callback || function() {};
         if(cache) {
@@ -90,7 +89,7 @@
     }
 
     function hasSubscription(productId, callback) {
-        var cache = this.Cache && this.Cache.enabled() ? this.Cache : null,
+        var cache = this.Persist,
             util = this.Util;
         callback = callback || function() {};
         if(cache) {
@@ -117,8 +116,8 @@
     function logout(callback) {
         var that = this;
         var cb = function(err, data) {
-            if(data.result && that.Cookie && that.Cookie.enabled()) {
-                that.Cookie.clear();
+            if(data.result) {
+                that.Persist.clear("Session");
             }
             if(callback) {
                 callback(err, data);

--- a/test/index.html
+++ b/test/index.html
@@ -29,6 +29,9 @@
         <script src="../src/spid-uri.js" data-cover></script>
         <script src="../src/spid-cache.js" data-cover></script>
         <script src="../src/spid-cookie.js" data-cover></script>
+        <script src="../src/spid-localstorage.js" data-cover></script>
+        <script src="../src/spid-persist.js" data-cover></script>
+
 
         <!-- Spec files -->
         <script src="./spec/spid-sdk_test.js"></script>
@@ -40,6 +43,8 @@
         <script src="./spec/spid-uri_test.js"></script>
         <script src="./spec/spid-cache_test.js"></script>
         <script src="./spec/spid-cookie_test.js"></script>
+        <script src="./spec/spid-localstorage_test.js"></script>
+        <script src="./spec/spid-persist_test.js"></script>
 
         <div id="mocha"></div>
     </body>

--- a/test/spec/spid-cache_test.js
+++ b/test/spec/spid-cache_test.js
@@ -7,41 +7,16 @@
 describe('SPiD.Cache', function() {
 
     var assert = chai.assert;
-    var setupEnabled = {client_id : '4d00e8d6bf92fc8648000000', server: 'stage.payment.schibsted.se', prod: false};
-    var setupDisabled = {client_id : '4d00e8d6bf92fc8648000000', server: 'stage.payment.schibsted.se', prod: false, cache:false};
-
-    describe('SPiD.Cache Disabled', function() {
-        before(function() {
-            SPiD.init(setupDisabled);
-        });
-
-        it('SPiD.Cache.enabled should return false when disabled', function() {
-            assert.isFalse(
-                SPiD.Cache.enabled()
-            );
-        });
-        it('SPiD.Cache.get should return undefined when disabled', function() {
-            SPiD.Cache.set('mykey', 'test');
-            assert.isUndefined(
-                SPiD.Cache.get('mykey')
-            );
-        });
-    });
+    var setupEnabled = {client_id: '4d00e8d6bf92fc8648000000', server: 'stage.payment.schibsted.se', prod: false};
 
     describe('SPiD.Cache Enabled', function() {
         before(function() {
             SPiD.init(setupEnabled);
         });
 
-        it('SPiD.Cache.enabled should return true', function() {
-            assert.isTrue(
-                SPiD.Cache.enabled()
-            );
-        });
-
         it('SPiD.Cache.encode should return escaped JSON', function() {
             assert.equal(
-                SPiD.Cache.encode({str:'val',test:true}),
+                SPiD.Cache.encode({str: 'val', test: true}),
                 '%7B%22str%22%3A%22val%22%2C%22test%22%3Atrue%7D'
             );
         });
@@ -49,7 +24,7 @@ describe('SPiD.Cache', function() {
         it('SPiD.Cache.decode should return object', function() {
             assert.deepEqual(
                 SPiD.Cache.decode('%7B%22str%22%3A%22val%22%2C%22test%22%3Atrue%7D'),
-                {str:'val',test:true}
+                {str: 'val', test: true}
             );
         });
 
@@ -59,7 +34,7 @@ describe('SPiD.Cache', function() {
         });
 
         it('SPiD.Cache.get should return value set', function() {
-            var val = {user:123, productId: 10010, result: true};
+            var val = {user: 123, productId: 10010, result: true};
             SPiD.Cache.set('mykey', val);
 
             assert.deepEqual(
@@ -69,7 +44,7 @@ describe('SPiD.Cache', function() {
         });
 
         it('SPiD.Cache.clear should remove set key', function() {
-            var set = {user:123, productId: 10010, result: true};
+            var set = {user: 123, productId: 10010, result: true};
             SPiD.Cache.set('mykeytoremove', set);
             SPiD.Cache.clear('mykeytoremove');
 

--- a/test/spec/spid-cache_test.js
+++ b/test/spec/spid-cache_test.js
@@ -7,7 +7,7 @@
 describe('SPiD.Cache', function() {
 
     var assert = chai.assert;
-    var setupEnabled = {client_id: '4d00e8d6bf92fc8648000000', server: 'stage.payment.schibsted.se', prod: false};
+    var setupEnabled = {client_id: '4d00e8d6bf92fc8648000000', server: 'identity-pre.schibsted.com', prod: false};
 
     describe('SPiD.Cache Enabled', function() {
         before(function() {

--- a/test/spec/spid-cookie_test.js
+++ b/test/spec/spid-cookie_test.js
@@ -21,11 +21,6 @@ describe('SPiD.Cookie', function() {
                 'spid_js_'+setup.client_id
             );
         });
-        it('SPiD.Cookie.enabled should return false', function() {
-            assert.isFalse(
-                SPiD.Cookie.enabled()
-            );
-        });
     });
 
     describe('SPiD.Cookie Stage', function() {
@@ -39,13 +34,6 @@ describe('SPiD.Cookie', function() {
                 'spid_js_test_'+setup.client_id
             );
         });
-
-        it('SPiD.Cookie.enabled should return true', function() {
-            assert.isTrue(
-                SPiD.Cookie.enabled()
-            );
-        });
-
         it('SPiD.Cookie.encode should return escaped JSON', function() {
             assert.equal(
                 SPiD.Cookie.encode({str:'val',test:true}),

--- a/test/spec/spid-localstorage_test.js
+++ b/test/spec/spid-localstorage_test.js
@@ -7,17 +7,41 @@ describe('SPiD.Localstorage', function() {
 
     var assert = chai.assert;
 
-    it('SPiD.Localstorage.set/get should work ', function() {
+    it(' set/get should work ', function() {
         var data = {"I": "love", "to:": {"nest": "data"}};
         SPiD.LocalStorage.set("test", data);
         assert.isDefined(window.localStorage);
         assert.deepEqual(data, SPiD.LocalStorage.get("test"));
     });
 
-    it('SPiD.Localstorage.clear should clear ', function() {
+    it(' clear should clear ', function() {
         var data = "xxx";
         SPiD.LocalStorage.set("test", data);
         SPiD.LocalStorage.clear("test");
         assert.isNull(SPiD.LocalStorage.get("test"));
     });
+
+    it(' passing an expires parameter should add expires field that\'s in the future', function() {
+        var data = {"thought" : "leader"};
+        SPiD.LocalStorage.set("test", data, 100);
+        var storedData = JSON.parse(window.localStorage.getItem("SPiD_test"));
+        var time = new Date(storedData._expires).getTime();
+        assert.closeTo(new Date().getTime() +100*1000 ,time, 1000 );
+    });
+
+    it(' NOT passing an expires parameter should NOT add expires field', function() {
+        var data = {"thought" : "leader"};
+        SPiD.LocalStorage.set("test", data);
+        var storedData = window.localStorage.getItem("SPiD_test");
+        assert.isUndefined(storedData._expires);
+    });
+
+    it(' reading an expired object should remove it from storage and return null ', function() {
+        var expired = {"thought" : "leader", "_expires" : new Date(1337) };
+        window.localStorage.setItem("SPiD_test", JSON.stringify(expired));
+        assert.isNull(SPiD.LocalStorage.get("test"));
+        assert.isNull( window.localStorage.getItem("SPiD_test"));
+    });
+
+
 });

--- a/test/spec/spid-localstorage_test.js
+++ b/test/spec/spid-localstorage_test.js
@@ -1,0 +1,23 @@
+/*global chai:false*/
+/*global describe:false*/
+/*global it:false*/
+/*global SPiD:false*/
+
+describe('SPiD.Localstorage', function() {
+
+    var assert = chai.assert;
+
+    it('SPiD.Localstorage.set/get should work ', function() {
+        var data = {"I": "love", "to:": {"nest": "data"}};
+        SPiD.LocalStorage.set("test", data);
+        assert.isDefined(window.localStorage);
+        assert.deepEqual(data, SPiD.LocalStorage.get("test"));
+    });
+
+    it('SPiD.Localstorage.clear should clear ', function() {
+        var data = "xxx";
+        SPiD.LocalStorage.set("test", data);
+        SPiD.LocalStorage.clear("test");
+        assert.isNull(SPiD.LocalStorage.get("test"));
+    });
+});

--- a/test/spec/spid-persist_test.js
+++ b/test/spec/spid-persist_test.js
@@ -1,0 +1,102 @@
+/*global chai:false*/
+/*global describe:false*/
+/*global it:false*/
+/*global SPiD:false*/
+
+describe('SPiD.Persist', function() {
+
+    var assert = chai.assert;
+    var setup = {storage: null, client_id: 'xxx', server: 'payment.schibsted.se'};
+
+    describe('SPiD no-storage setup', function() {
+        it('SPiD.Persist default should have set/get/clear methods ', function() {
+            SPiD.init(setup);
+            assert.isFunction(SPiD.Persist.get);
+            assert.isFunction(SPiD.Persist.set);
+            assert.isFunction(SPiD.Persist.clear);
+        });
+    });
+
+    describe(' with cookies setup ', function() {
+        var SPiDCookie;
+        before(function() {
+            var cookieSetup = setup;
+            cookieSetup.storage = 'cookie';
+            SPiD.init(cookieSetup);
+            SPiDCookie = SPiD.Cookie;
+        });
+
+        it('should have set/get/clear methods ', function() {
+            assert.isFunction(SPiD.Persist.get);
+            assert.isFunction(SPiD.Persist.set);
+            assert.isFunction(SPiD.Persist.clear);
+        });
+
+        it('should have a get method that calls through to SPiD.Cookie ', function(done) {
+            SPiD.Cookie.get = function(key) {
+                assert.equal('some', key);
+                done();
+            };
+            SPiD.Persist.get('some');
+        });
+
+        it('should have a set method that calls through to SPiD.Cookie ', function(done) {
+            SPiD.Cookie.set = function(key, value) {
+                assert.equal('key', key);
+                assert.equal('value', value);
+                done();
+            };
+            SPiD.Persist.set('key', 'value');
+        });
+
+        it('should have a clear method that calls through to SPiD.Cookie', function(done) {
+            SPiD.Cookie.clear = function(key) {
+                assert.isUndefined(key);
+                done();
+            };
+            SPiD.Persist.clear();
+        });
+    });
+
+    describe(' with local storage setup ', function() {
+        var SPiDLS;
+        before(function() {
+            var lsSetup = setup;
+            lsSetup.storage = 'localstorage';
+            SPiD.init(lsSetup);
+            SPiDLS = SPiD.LocalStorage;
+        });
+
+        it('should have set/get/clear methods ', function() {
+            assert.isFunction(SPiD.Persist.get);
+            assert.isFunction(SPiD.Persist.set);
+            assert.isFunction(SPiD.Persist.clear);
+        });
+
+        it('should have a get method that calls through to SPiD.LocalStorage ', function(done) {
+            SPiD.LocalStorage.get = function(key) {
+                assert.equal('some', key);
+                done();
+            };
+            SPiD.Persist.get('some');
+        });
+
+        it('should have a set method that calls through to SPiD.LocalStorage ', function(done) {
+            SPiD.LocalStorage.set = function(key, value) {
+                assert.equal('key', key);
+                assert.equal('value', value);
+                done();
+            };
+            SPiD.Persist.set('key', 'value');
+        });
+
+        it('should have a clear method that calls through to SPiD.LocalStorage', function(done) {
+            SPiD.LocalStorage.clear = function(key) {
+                assert.equal('key', key);
+                done();
+            };
+            SPiD.Persist.clear("key");
+        });
+    });
+
+});

--- a/test/spec/spid-persist_test.js
+++ b/test/spec/spid-persist_test.js
@@ -95,7 +95,48 @@ describe('SPiD.Persist', function() {
                 assert.equal('key', key);
                 done();
             };
-            SPiD.Persist.clear("key");
+            SPiD.Persist.clear('key');
+        });
+    });
+
+    describe(' with cache setup ', function() {
+        var SPiDCache;
+        before(function() {
+            var cacheSetup = setup;
+            cacheSetup.storage = 'cache';
+            SPiD.init(cacheSetup);
+            SPiDCache = SPiD.Cache;
+        });
+
+        it('should have set/get/clear methods ', function() {
+            assert.isFunction(SPiD.Persist.get);
+            assert.isFunction(SPiD.Persist.set);
+            assert.isFunction(SPiD.Persist.clear);
+        });
+
+        it('should have a get method that calls through to SPiD.Cache ', function(done) {
+            SPiD.Cache.get = function(key) {
+                assert.equal('some', key);
+                done();
+            };
+            SPiD.Persist.get('some');
+        });
+
+        it('should have a set method that calls through to SPiD.Cache ', function(done) {
+            SPiD.Cache.set = function(key, value) {
+                assert.equal('key', key);
+                assert.equal('value', value);
+                done();
+            };
+            SPiD.Persist.set('key', 'value');
+        });
+
+        it('should have a clear method that calls through to SPiD.Cache', function(done) {
+            SPiD.Cache.clear = function(key) {
+                assert.equal('key', key);
+                done();
+            };
+            SPiD.Persist.clear('key');
         });
     });
 

--- a/test/spec/spid-sdk_test.js
+++ b/test/spec/spid-sdk_test.js
@@ -8,8 +8,8 @@
 describe('SPiD', function() {
 
     var assert = chai.assert;
-    var setup = {client_id : '4d00e8d6bf92fc8648000000', server: 'stage.payment.schibsted.se', prod:false, logging:false, cache:true, storage: 'cookie'};
-    var setupProd = {client_id : '4d00e8d6bf92fc8648000000', server: 'payment.schibsted.se', logging:false, refresh_timeout: 100, storage: 'cookie'};
+    var setup = {client_id : '4d00e8d6bf92fc8648000000', server: 'identity-pre.schibsted.com', prod:false, logging:false, cache:true, storage: 'cookie'};
+    var setupProd = {client_id : '4d00e8d6bf92fc8648000000', server: 'login.schibsted.com', logging:false, refresh_timeout: 100, storage: 'cookie'};
 
     describe('SPiD.init', function() {
         it('SPiD.init should throw error when missing config', function() {
@@ -29,21 +29,21 @@ describe('SPiD', function() {
         it('SPiD.server should return URL to Core server', function() {
             assert.equal(
                 SPiD.server(),
-                'https://payment.schibsted.se/'
+                'https://login.schibsted.com/'
             );
         });
 
         it('SPiD.sessionEndpoint should return URL to Session server endpoint', function() {
             assert.equal(
                 SPiD.sessionEndpoint(),
-                'https://session.payment.schibsted.se/rpc/hasSession.js'
+                'https://session.login.schibsted.com/rpc/hasSession.js'
             );
         });
 
         it('SPiD.coreEndpoint should return URL to Core Session server endpoint', function() {
             assert.equal(
                 SPiD.coreEndpoint(),
-                'https://payment.schibsted.se/ajax/hasSession.js'
+                'https://login.schibsted.com/ajax/hasSession.js'
             );
         });
     });
@@ -55,20 +55,20 @@ describe('SPiD', function() {
         it('SPiD.server should return URL to Core server', function() {
             assert.equal(
                 SPiD.server(),
-                'https://stage.payment.schibsted.se/'
+                'https://identity-pre.schibsted.com/'
             );
         });
 
         it('SPiD.sessionEndpoint should return URL to Core Session server endpoint', function() {
             assert.equal(
                 SPiD.sessionEndpoint(),
-                'https://stage.payment.schibsted.se/ajax/hasSession.js'
+                'https://identity-pre.schibsted.com/ajax/hasSession.js'
             );
         });
         it('SPiD.coreEndpoint should return URL to Core Session server endpoint', function() {
             assert.equal(
                 SPiD.coreEndpoint(),
-                'https://stage.payment.schibsted.se/ajax/hasSession.js'
+                'https://identity-pre.schibsted.com/ajax/hasSession.js'
             );
         });
     });
@@ -108,7 +108,7 @@ describe('SPiD', function() {
 
         it('SPiD.hasSession should call Talk with parameter server, path, params, callback', function() {
             SPiD.Talk.request = function(server, path, param, callback) {
-                assert.equal(server, 'https://session.payment.schibsted.se/rpc/hasSession.js');
+                assert.equal(server, 'https://session.login.schibsted.com/rpc/hasSession.js');
                 assert.isNull(path);
                 assert.equal(param.autologin, 1);
                 assert.isFunction(callback);
@@ -120,7 +120,7 @@ describe('SPiD', function() {
             var calledOnce = false;
             SPiD.Talk.request = function(server, path, param, callback) {
                 if(calledOnce) {
-                    assert.equal(server, 'https://payment.schibsted.se/ajax/hasSession.js');
+                    assert.equal(server, 'https://login.schibsted.com/ajax/hasSession.js');
                     assert.isNull(path);
                     assert.equal(param.autologin, 1);
                     assert.isFunction(callback);
@@ -180,7 +180,7 @@ describe('SPiD', function() {
 
         it('SPiD.hasProduct should call Talk with parameter server, path, params, callback', function() {
             SPiD.Talk.request = function(server, path, param, callback) {
-                assert.equal(server, 'https://stage.payment.schibsted.se/');
+                assert.equal(server, 'https://identity-pre.schibsted.com/');
                 assert.equal(path, 'ajax/hasproduct.js');
                 assert.equal(param.product_id, 10010);
                 assert.isFunction(callback);
@@ -251,7 +251,7 @@ describe('SPiD', function() {
 
         it('SPiD.hasSubscription should call Talk with parameter server, path, params, callback', function() {
             SPiD.Talk.request = function(server, path, param, callback) {
-                assert.equal(server, 'https://stage.payment.schibsted.se/');
+                assert.equal(server, 'https://identity-pre.schibsted.com/');
                 assert.equal(path, 'ajax/hassubscription.js');
                 assert.equal(param.product_id, 10010);
                 assert.isFunction(callback);
@@ -318,7 +318,7 @@ describe('SPiD', function() {
 
         it('SPiD.setTraits should call Talk with parameter server, path, params, callback', function() {
             SPiD.Talk.request = function(server, path, param, callback) {
-                assert.equal(server, 'https://stage.payment.schibsted.se/');
+                assert.equal(server, 'https://identity-pre.schibsted.com/');
                 assert.equal(path, 'ajax/traits.js');
                 assert.equal(param.t, 'traitObject');
                 assert.isFunction(callback);
@@ -342,7 +342,7 @@ describe('SPiD', function() {
 
         it('SPiD.logout should call Talk with parameter server, path, params, callback', function() {
             SPiD.Talk.request = function(server, path, param, callback) {
-                assert.equal(server, 'https://stage.payment.schibsted.se/');
+                assert.equal(server, 'https://identity-pre.schibsted.com/');
                 assert.equal(path, 'ajax/logout.js');
                 assert.isFunction(callback);
             };


### PR DESCRIPTION
This PR adds a module for writing data, specifically the contents of the `hasSession` response, to *local storage*.  Additionally, it removes the methods `SPiD.Cookie.enabled()` `SPiD.Cache.enabled()` and the related configuration options&mdash;having `enabled` *and* the `SPiD.Persist` wrapper feels redundant. Also: `SPiD.persist` is now used in calls to `SPiD.hasProduct`, `SPiD.logout()` and `SPiD.hasSubscription`, rather than `SPiD.Cache`. 

The `SPiD.Persist` module will delegate to other SPiD modules, based on the configuration option `storage`:
 - `localstorage` -> SPiD.LocalStorage
 - `cookie` -> SPiD.Cookie
 - `cache` -> SPiD.Cache
 - `null` || `standard ` -> no-op  

The default is to use LocalStorage.


Your thoughts, @joawan + @erikfried ?