### PR TITLE
WIP: Use a less cool, but backwards compatible, SPiD.Talk (formerly VGS.Ajax) module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
           'src/spid-sdk.js',
           'src/spid-log.js',
           'src/spid-util.js',
-          'src/spid-talk.js',
+          'src/spid-talk-backwards-compatible.js',
           'src/spid-cookie.js',
           'src/spid-cache.js',
           'src/spid-uri.js',

--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -29,7 +29,7 @@
             _options.refresh_timeout = 60000;
         }
         // For a backwards compatible Talk module
-        if(this.Talk.init) {
+        if(this.Talk && this.Talk.init) {
             this.Talk.init(_options);
         }
 

--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -28,6 +28,10 @@
         if(_options.refresh_timeout <= 60000) {
             _options.refresh_timeout = 60000;
         }
+        // For a backwards compatible Talk module
+        if(this.Talk.init) {
+            this.Talk.init(_options);
+        }
 
         _initiated = true;
         if(callback) {

--- a/src/spid-talk-backwards-compatible.js
+++ b/src/spid-talk-backwards-compatible.js
@@ -1,0 +1,189 @@
+;(function(exports) {
+
+    var logger = exports.Log,
+        _callbacks = [],
+        _ajax = {
+            connectionId: -1,
+            connections: [],
+            interval: null,
+            intervalPeriod: 300, // strongly suggested that you increase this to 1000 if debugging!!
+            pollingDebugCount: 0,
+            pollingDebugFirst: true,
+            pollingDebugThrottle: 100, // show a debug message after every this many polling iterations
+            requestQueue: [],
+            scriptObject: null,
+            serverUrl: '',
+            sessionUrl: '',
+            timeoutPeriod: 5000, // if a connection goes on for longer than this many milliseconds, then timeout
+            version: '1.0'
+        };
+
+    function _guid() {
+        return 'f' + (Math.random() * (1 << 30)).toString(16).replace('.', '');
+    }
+
+    function _flushQueue() {
+        logger.log('SPiD.Talk.flushQueue()');
+        _ajax.requestQueue.length = 0;
+    }
+
+    function _stopPolling() {
+        logger.log('SPiD.Talk.stopPolling()');
+        _ajax.serverTimeoutTime = null;
+        _flushQueue();
+        if(_ajax.interval) {
+            window.clearInterval(_ajax.interval);
+        }
+        _ajax.interval = null;
+    }
+
+    function _startPolling() {
+        logger.log('SPiD.Talk.startPolling()');
+        if(_ajax.interval == null) {
+            logger.log('polling (re)started');
+            _ajax.connections[_ajax.connectionId] = null;
+            _poll();
+            _ajax.interval = window.setInterval(function() {
+                _ajax.connections[_ajax.connectionId] = null;
+                _poll();
+            }, _ajax.intervalPeriod);
+        }
+    }
+
+    function _now() {
+        return (new Date()).getTime();
+    }
+
+    function _poll() {
+        logger.log('SPiD.Talk.poll()');
+        if(_ajax.pollingDebugCount === _ajax.pollingDebugThrottle) {
+            logger.log('-- poll [' + _now() + '] (x' + _ajax.pollingDebugCount + ')');
+            _ajax.pollingDebugCount = 0;
+        } else if(_ajax.pollingDebugFirst) {
+            logger.log('-- poll [' + _now() + ']');
+            _ajax.pollingDebugFirst = false;
+            _ajax.pollingDebugCount = 0;
+        }
+        _ajax.pollingDebugCount++;
+        if(_ajax.serverTimeoutTime) {
+            if(_ajax.serverTimeoutTime <= _now()) {
+                _stopPolling();
+                _failure('Server Timed Out');
+            } else if(parent.triggerResponse != null) {
+                parent.triggerResponse();
+            }
+        } else if(_ajax.requestQueue.length > 0) {
+            // Queue size validation in order to avoid abuse and overload of the platform. Allow max 10 requests in the queue.
+            if(_ajax.requestQueue.length > 10) {
+                _failure("Queue size too big: " + _ajax.requestQueue.length + " requests! In order to avoid abuse and overload of the platform we allow max 10 requests in the queue.");
+                _stopPolling();
+            } else {
+                _makeRequest();
+            }
+        } else {
+            _stopPolling();
+        }
+    }
+
+    function _failure(errorMsg) {
+        logger.log('SPiD.Talk.failure("' + errorMsg + '")');
+        if(exports.Event) {
+            exports.Event.fire('SPiD.error', {'type': 'communication', 'code': 503, 'description': errorMsg});
+        }
+    }
+
+
+    function _makeRequest() {
+        logger.log('SPiD.Talk.makeRequest()');
+        if(_ajax.requestQueue.length > 0) {
+            logger.log('Processing: on'); // fkn dumb
+            var connectionCode = _ajax.requestQueue[0].connectionUrl;
+            parent.triggerResponse = null;
+            _createScriptObject(connectionCode);
+            _ajax.serverTimeoutTime = _now() + _ajax.timeoutPeriod;
+        }
+    }
+
+    function _createScriptObject(source) {
+        logger.log('SPiD.Talk.createScriptObject("' + source + '")');
+        _ajax.scriptObject = document.createElement('SCRIPT');
+        _ajax.scriptObject.src = source;
+        _ajax.scriptObject.type = 'text/javascript';
+        _ajax.scriptObject.onerror = loadingError;
+        var head = document.getElementsByTagName('HEAD')[0];
+        head.appendChild(_ajax.scriptObject);
+    }
+
+    function _buildConnectionUrl(queryParam, id) {
+        var query = queryParam + '&callback=' + id;
+        logger.log('SPiD.Talk.buildConnectionUrl("' + query + '")');
+        _ajax.connectionId = _ajax.connections.length;
+
+        var client_id = exports.options().client_id,
+            redirect_uri = window.location.toString();
+
+        var url = ((query.substr(0, 4) === 'http') ? query : _ajax.serverUrl + query) + '&connectionId=' + _ajax.connectionId + '&client_id=' + client_id + '&redirect_uri=' + (encodeURIComponent(redirect_uri));
+        logger.log('-- built url: [' + url + ']');
+        _ajax.requestQueue[_ajax.requestQueue.length] = _makeRequestQueueNode(url);
+    }
+
+    function _makeRequestQueueNode(url) {
+        logger.log('Creating a new requestQueueNode("' + url + '")');
+        return {
+            connectionUrl: url,
+            requestSent: false
+        };
+    }
+
+    function loadingError() {
+        logger.log('SPiD.Talk.loadingError()');
+        _stopPolling();
+        _failure('Server Timed Out');
+    }
+
+    function send(query, callback) {
+        // Add the callback to the callbacks object
+        var id = _guid();
+        _callbacks[id] = callback;
+        logger.log('SPiD.Talk.send("' + query + '")');
+        _buildConnectionUrl(query, id);
+        _startPolling();
+    }
+
+    function init(options) {
+        // Ported from VGS.init, should be applied on SPiD.init ???
+        _ajax.timeoutPeriod = options.timeout || _ajax.timeoutPeriod;
+        _ajax.serverUrl = (options.https ? 'https' : 'http') + '://' + options.server + '/';
+        if(options.prod) {
+            _ajax.sessionUrl = (options.https ? 'https' : 'http') + '://session.' + options.server + '/rpc/hasSession.js';
+        } else {
+            _ajax.sessionUrl = (options.https ? 'https' : 'http') + '://' + options.server + '/ajax/hasSession.js';
+        }
+    }
+
+    function _removeScriptObject() {
+        logger.log('SPiD.Talk.removeScriptObject()', 'log');
+        _ajax.scriptObject.parentNode.removeChild(_ajax.scriptObject);
+        _ajax.scriptObject = null;
+    }
+
+    function _responseReceived() {
+        logger.log('SPiD.Talk.responseReceived()');
+        logger.log('Processing: off');
+        _ajax.requestQueue.shift();
+        _ajax.serverTimeoutTime = null;
+        _removeScriptObject();
+    }
+
+    exports.VGS = {
+        Ajax: {
+            responseReceived: _responseReceived
+        },
+        callbacks: _callbacks
+    };
+
+    exports.Talk = {
+        request: send,
+        init: init
+    };
+}(window));

--- a/test/index.html
+++ b/test/index.html
@@ -25,7 +25,7 @@
         <script src="../src/spid-util.js" data-cover></script>
         <script src="../src/spid-event.js" data-cover></script>
         <script src="../src/spid-event-trigger.js" data-cover></script>
-        <script src="../src/spid-talk.js" data-cover></script>
+        <script src="../src/spid-talk-backwards-compatible.js" data-cover></script>
         <script src="../src/spid-uri.js" data-cover></script>
         <script src="../src/spid-cache.js" data-cover></script>
         <script src="../src/spid-cookie.js" data-cover></script>
@@ -36,7 +36,7 @@
         <script src="./spec/spid-util_test.js"></script>
         <script src="./spec/spid-event_test.js"></script>
         <script src="./spec/spid-event-trigger_test.js"></script>
-        <script src="./spec/spid-talk_test.js"></script>
+        <script src="./spec/spid-talk-backwards-compatible_test.js"></script>
         <script src="./spec/spid-uri_test.js"></script>
         <script src="./spec/spid-cache_test.js"></script>
         <script src="./spec/spid-cookie_test.js"></script>

--- a/test/mock/spid-talk-backwards-compatible_response-hasSession-sucess.js
+++ b/test/mock/spid-talk-backwards-compatible_response-hasSession-sucess.js
@@ -1,0 +1,13 @@
+function triggerResponse(){
+    var json = {"result":true,"serverTime":1390824533,"expiresIn":7111,"baseDomain":"sdk.dev","visitor":{"uid":"15lswsXms7xoaXpdd852","user_id":"1844813"},"userStatus":"connected","userId":1844813,"id":"4f1e2ae59caf7c2f4a058b76","displayName":"Joakim Developer","givenName":"Joakim","familyName":"Developer","gender":"male","photo":"https:\/\/secure.gravatar.com\/avatar\/ec32937c22d1a4b1474657b776d0f398?s=200","sig":"5nqQdhfEvkcMqFr2XEgOrRCAtXn_H4_1EN_Qp-j_SCU.eyJyZXN1bHQiOnRydWUsInNlcnZlclRpbWUiOjEzOTA4MjQ1MzMsImV4cGlyZXNJbiI6NzExMSwiYmFzZURvbWFpbiI6Ind3dy5hZnRvbmJsYWRldC5zZSIsInZpc2l0b3IiOnsidWlkIjoiMTVsc3dzWG1zN3hvYVhwZGQ4NTIiLCJ1c2VyX2lkIjoiMTg0NDgxMyJ9LCJ1c2VyU3RhdHVzIjoiY29ubmVjdGVkIiwidXNlcklkIjoxODQ0ODEzLCJpZCI6IjRmMWUyYWU1OWNhZjdjMmY0YTA1OGI3NiIsImRpc3BsYXlOYW1lIjoiSm9ha2ltIFdcdTAwZTVuZ2dyZW4iLCJnaXZlbk5hbWUiOiJKb2FraW0iLCJmYW1pbHlOYW1lIjoiV1x1MDBlNW5nZ3JlbiIsImdlbmRlciI6Im1hbGUiLCJwaG90byI6Imh0dHBzOlwvXC9zZWN1cmUuZ3JhdmF0YXIuY29tXC9hdmF0YXJcL2VjMzI5MzdjMjJkMWE0YjE0NzQ2NTdiNzc2ZDBmMzk4P3M9MjAwIiwiYWxnb3JpdGhtIjoiSE1BQy1TSEEyNTYifQ"};
+
+    //Not part of response. Hack to get the callback id
+    var scripts = document.head.getElementsByTagName('script');
+    var src = scripts[scripts.length-1].src;
+    var id = src.match(/callback=[0-9a-f]+/i).pop().split("=").pop();
+
+    if(VGS) {
+        VGS.callbacks[id](json);
+        parent.VGS.Ajax.responseReceived();
+    }
+}

--- a/test/spec/spid-talk-backwards-compatible_test.js
+++ b/test/spec/spid-talk-backwards-compatible_test.js
@@ -1,0 +1,33 @@
+/*global chai:false*/
+/*global describe:false*/
+/*global it:false*/
+/*global SPiD:false*/
+
+describe('SPiD.Talk (the backwards compatible one)', function() {
+
+    var assert = chai.assert;
+
+    var serverUrl = './mock/';
+
+    var setup = {
+        client_id: '4d00e8d6bf92fc8648000000',
+        server: 'stage.payment.schibsted.se',
+        serverUrl: serverUrl,
+        prod: false,
+        logging: false,
+        timeout: 500,
+        _testMode: true
+    };
+
+
+    it('Make that request!', function(done) {
+        var query = './mock/spid-talk-backwards-compatible_response-hasSession-sucess.js?a=b';
+        SPiD.init(setup);
+        SPiD.Talk.request(query, function(res) {
+            if(res) {
+                done();
+            }
+        });
+    });
+
+});


### PR DESCRIPTION
The reasoning behind this PR is as follows:
 1. If we can avoid having to push out a new SPiD backend simply in order to launch a new client, that would be a Good Thing™
 2. If we can start using the backend by simply replacing it's `Spid.Talk` module, that _should_ make upgrading the SDK pretty painless for the SDK users (e.g. Aftonbladet).
 3. Ain't no shame in copy/paste programming

Writing unit tests is still TODO, but we should be able to do *actual tests* with this PR (i.e. running a minified client on some sort of test environment, making sure we've implemented everything). 

ping @joawan (et al)