### PR TITLE
Localstorage module should use client_id as part of the key

### DIFF
--- a/src/spid-localstorage.js
+++ b/src/spid-localstorage.js
@@ -1,5 +1,6 @@
 /*global require:false, module:false*/
 var log = require('./spid-log'),
+    config = require('./spid-config'),
     keyPrefix = 'SPiD_',
     enabled = true;
 
@@ -12,7 +13,7 @@ function encode(value) {
 }
 
 function _toKey(key) {
-    return keyPrefix + key;
+    return keyPrefix + config.options().client_id + '_' + key;
 }
 
 function set(key, value, expiresInSeconds) {

--- a/test/spec/spid-localstorage_test.js
+++ b/test/spec/spid-localstorage_test.js
@@ -1,7 +1,15 @@
 describe('SPiD.Localstorage', function() {
 
-    var assert = chai.assert;
-    var storage  = require('../../src/spid-localstorage');
+    var assert = chai.assert,
+        setup = {client_id: 'xxx', server: 'payment-pre.schibsted.com'},
+        SPiD,
+        storage;
+
+    beforeEach(function() {
+        SPiD = require('../../src/spid-sdk');
+        SPiD.init(setup);
+        storage = require('../../src/spid-localstorage');
+    });
 
     it(' set/get should work ', function() {
         var data = {'I': 'love', 'to:': {'nest': 'data'}};
@@ -11,7 +19,7 @@ describe('SPiD.Localstorage', function() {
     });
 
     it(' clear should clear ', function() {
-        var data = 'xxx';
+        var data = 'such data';
         storage.set('test', data);
         storage.clear('test');
         assert.isNull(storage.get('test'));
@@ -20,7 +28,7 @@ describe('SPiD.Localstorage', function() {
     it(' passing an expires parameter should add expires field that\'s in the future', function() {
         var data = {'thought' : 'leader'};
         storage.set('test', data, 100);
-        var storedData = JSON.parse(window.localStorage.getItem('SPiD_test'));
+        var storedData = JSON.parse(window.localStorage.getItem('SPiD_xxx_test'));
         var time = new Date(storedData._expires).getTime();
         assert.closeTo(new Date().getTime() +100*1000 ,time, 1000 );
     });
@@ -28,15 +36,15 @@ describe('SPiD.Localstorage', function() {
     it(' NOT passing an expires parameter should NOT add expires field', function() {
         var data = {'thought' : 'leader'};
         storage.set('test', data);
-        var storedData = window.localStorage.getItem('SPiD_test');
+        var storedData = window.localStorage.getItem('SPiD_xxx_test');
         assert.isUndefined(storedData._expires);
     });
 
     it(' reading an expired object should remove it from storage and return null ', function() {
         var expired = {'thought' : 'leader', '_expires' : new Date(1337) };
-        window.localStorage.setItem('SPiD_test', JSON.stringify(expired));
+        window.localStorage.setItem('SPiD_xxx_test', JSON.stringify(expired));
         assert.isNull(storage.get('test'));
-        assert.isNull( window.localStorage.getItem('SPiD_test'));
+        assert.isNull( window.localStorage.getItem('SPiD_xxx_test'));
     });
 
 


### PR DESCRIPTION
The localstorage module should include the client_id in the key used to store session data, to avoid multiple clients on the same domain overwriting each others session data.

Closes #16 

@erikfried @joawan 