### PR TITLE
19 enable force refresh

### DIFF
--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -142,8 +142,8 @@ function logout(callback) {
 function acceptAgreement(callback) {
     var that = this;
     var cb = function() {
-        persist.clear();
-        that.hasSession(callback);
+        var forceServerReload = true;
+        that.hasSession(callback, forceServerReload);
     };
     talk.request(this.server(),'ajax/acceptAgreement.js', {}, cb);
 }

--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -27,7 +27,7 @@ function init(opts, callback) {
     }
 }
 
-function hasSession(callback) {
+function hasSession(callback, forceServerReload) {
     callback = callback || function() {
         };
     var that = this,
@@ -52,6 +52,10 @@ function hasSession(callback) {
             }
             handleResponse(err, data);
         };
+
+    if (forceServerReload === true) {
+        persist.clear();
+    }
 
     var data = persist.get();
     if(data) {


### PR DESCRIPTION
Add the ability to force server reloads and override the cached session state.

Useful when client knows user may have updated its state since last server reload.

Closes #19 

ping @thogra 