### PR TITLE
Add dev dependencies explicitly. Previous peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,20 +26,24 @@
   "main": "src/spid-sdk.js",
   "devDependencies": {
     "grunt": "~0.4.2",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-compress": "~0.13.0",
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-uglify": "~0.3.2",
-    "grunt-contrib-compress": "~0.13.0",
-    "grunt-contrib-clean": "~0.6.0",
+    "grunt-karma": "^0.12.1",
     "grunt-template": "~0.2.3",
     "grunt-webpack": "~1.0.3",
+    "istanbul-instrumenter-loader": "~0.1.3",
     "karma": "^0.13.9",
-    "grunt-karma": "^0.12.1",
-    "karma-sinon-chai":"~1.1",
-    "karma-phantomjs-launcher": "~0.2",
-    "karma-mocha": "~0.2",
-    "karma-webpack": "^1.7.0",
     "karma-coverage": "~0.5.2",
-    "istanbul-instrumenter-loader": "~0.1.3"
+    "karma-mocha": "~0.2",
+    "karma-phantomjs-launcher": "~0.2",
+    "karma-sinon-chai": "~1.1",
+    "karma-webpack": "^1.7.0",
+    "mocha": "^2.3.4",
+    "phantomjs": "^1.9.18",
+    "webpack": "^1.12.6",
+    "webpack-dev-server": "^1.12.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Since I am on version 3 of NPM I got errors when running `npm test` and `npm run build`.
Previously, in NPM@1 and NPM@2, the peer dependencies got loaded. This no longer happens in NPM@3 see https://docs.npmjs.com/files/package.json#peerdependencies.

I explicitly added the peer dependencies so it now works when someone is using NPM@3.

NB: Some other dependencies are also changed because they were out of order.

Picture of errors prior to this
![skjermbilde 2015-11-16 kl 12 56 46](https://cloud.githubusercontent.com/assets/288977/11182987/5a41efb4-8c6f-11e5-8e7f-f56a03bda131.png)
