### PR TITLE
Localstorage only removes single item, instead of clearing entire cache

### DIFF
--- a/src/spid-localstorage.js
+++ b/src/spid-localstorage.js
@@ -25,7 +25,7 @@ function set(key, value, expiresInSeconds) {
 
 function clear(key) {
     try {
-        window.localStorage.clear(key);
+        window.localStorage.removeItem(key);
     } catch(e) {
         log.info(e);
     }

--- a/test/spec/spid-localstorage_test.js
+++ b/test/spec/spid-localstorage_test.js
@@ -17,6 +17,20 @@ describe('SPiD.Localstorage', function() {
         assert.isNull(storage.get('test'));
     });
 
+    it(' clear only clears one key', function () {
+
+        var preExistingKey = 'a';
+        var valueStored = 'foo';
+        storage.set(preExistingKey, valueStored);
+
+        storage.set('b');
+        storage.clear('b');
+
+        var preExistingValueRead = storage.get('a');
+
+        assert.equal(valueStored, preExistingValueRead);
+    });
+
     it(' passing an expires parameter should add expires field that\'s in the future', function() {
         var data = {'thought' : 'leader'};
         storage.set('test', data, 100);
@@ -38,6 +52,5 @@ describe('SPiD.Localstorage', function() {
         assert.isNull(storage.get('test'));
         assert.isNull( window.localStorage.getItem('test'));
     });
-
 
 });


### PR DESCRIPTION
Solves #29 

Please, this is a very serious bug, so it would be great if you could get this released soon and deprecate any other 2.x releases.

The consequence of this bug was that as soon as session is refreshed using the local storage module, the entire localstorage was wiped. 