### PR TITLE
Explicit option to set varnish cookie

### DIFF
--- a/src/spid-config.js
+++ b/src/spid-config.js
@@ -8,6 +8,7 @@ var
         logging: false,
         useSessionCluster: true,
         https: true,
+        setVarnishCookie: null,
         storage: 'localstorage',
         timeout: 15000,
         refresh_timeout: 900000,

--- a/src/spid-persist.js
+++ b/src/spid-persist.js
@@ -2,13 +2,13 @@
 var config = require('./spid-config'),
     noop = function() {};
 
-function getPersistenceModule(name) {
+function getPersistenceModule() {
     var storages = {
         localstorage: require('./spid-localstorage'),
         cookie: require('./spid-cookie'),
         standard: {get: noop, set: noop, clear: noop}
     };
-    return storages[name || (config.options().storage || 'standard')];
+    return storages[(config.options().storage || 'standard')];
 }
 
 function name() {
@@ -16,21 +16,11 @@ function name() {
     return 'spid_js_' + options.client_id;
 }
 
-function tryVarnishCookie(session) {
-    var options = config.options();
-    if(session.sp_id &&
-        (options.setVarnishCookie === true ||
-        (options.storage === 'cookie' && options.setVarnishCookie !== false))) {
-        getPersistenceModule('cookie').setVarnishCookie(session, options);
-    }
-}
-
 module.exports = {
     get: function() {
         return getPersistenceModule().get(name());
     },
     set: function(value, expiresIn) {
-        tryVarnishCookie(value);
         return getPersistenceModule().set(name(), value, expiresIn);
     },
     clear: function() {

--- a/src/spid-persist.js
+++ b/src/spid-persist.js
@@ -2,13 +2,13 @@
 var config = require('./spid-config'),
     noop = function() {};
 
-function getPersistenceModule() {
+function getPersistenceModule(name) {
     var storages = {
         localstorage: require('./spid-localstorage'),
         cookie: require('./spid-cookie'),
         standard: {get: noop, set: noop, clear: noop}
     };
-    return storages[(config.options().storage || 'standard')];
+    return storages[name || (config.options().storage || 'standard')];
 }
 
 function name() {
@@ -16,11 +16,21 @@ function name() {
     return 'spid_js_' + options.client_id;
 }
 
+function tryVarnishCookie(session) {
+    var options = config.options();
+    if(session.sp_id &&
+        (options.setVarnishCookie === true ||
+        (options.storage === 'cookie' && options.setVarnishCookie !== false))) {
+        getPersistenceModule('cookie').setVarnishCookie(session, options);
+    }
+}
+
 module.exports = {
     get: function() {
         return getPersistenceModule().get(name());
     },
     set: function(value, expiresIn) {
+        tryVarnishCookie(value);
         return getPersistenceModule().set(name(), value, expiresIn);
     },
     clear: function() {

--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -28,15 +28,6 @@ function init(opts, callback) {
     }
 }
 
-function tryVarnishCookie(session) {
-    var options = config.options();
-    if(session.sp_id &&
-        (options.setVarnishCookie === true ||
-        (options.storage === 'cookie' && options.setVarnishCookie !== false))) {
-        cookie.setVarnishCookie(session, options);
-    }
-}
-
 function hasSession(callback) {
     callback = callback || function() {
         };
@@ -49,7 +40,7 @@ function hasSession(callback) {
         handleResponse = function(err, data) {
             if(!err && !!data.result) {
                 persist.set(data, data.expiresIn);
-                tryVarnishCookie(data);
+                cookie.tryVarnishCookie(data);
             }
             respond(err, data);
         },

--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -8,6 +8,7 @@ var
     spidEvent = require('./spid-event'),
     eventTrigger = require('./spid-event-trigger'),
     persist = require('./spid-persist'),
+    cookie = require('./spid-cookie'),
     cache = require('./spid-cache'),
     talk = require('./spid-talk');
 
@@ -27,6 +28,15 @@ function init(opts, callback) {
     }
 }
 
+function tryVarnishCookie(session) {
+    var options = config.options();
+    if(session.sp_id &&
+        (options.setVarnishCookie === true ||
+        (options.storage === 'cookie' && options.setVarnishCookie !== false))) {
+        cookie.setVarnishCookie(session, options);
+    }
+}
+
 function hasSession(callback) {
     callback = callback || function() {
         };
@@ -39,6 +49,7 @@ function hasSession(callback) {
         handleResponse = function(err, data) {
             if(!err && !!data.result) {
                 persist.set(data, data.expiresIn);
+                tryVarnishCookie(data);
             }
             respond(err, data);
         },

--- a/test/spec/spid-cookie_test.js
+++ b/test/spec/spid-cookie_test.js
@@ -35,7 +35,6 @@ describe('SPiD.Cookie', function() {
         });
 
         it('SPiD.Cookie.set should set session cookie', function() {
-
             var session = {user:123, expiresIn: 5000, baseDomain: cookieDomain};
             var name = 'name';
             spidCookie.set(name, session, session.expiresIn);
@@ -43,9 +42,9 @@ describe('SPiD.Cookie', function() {
             assert.notEqual(document.cookie.indexOf(name), -1);
         });
 
-        it('SPiD.Cookie.set should set varnish cookie', function() {
+        it('SPiD.Cookie.setVarnishCookie should set varnish cookie', function() {
             var session = {user:123, sp_id: 123, expiresIn: 5000, baseDomain: cookieDomain};
-            spidCookie.set('name', session, session.expiresIn);
+            spidCookie.setVarnishCookie(session, session.expiresIn);
 
             assert.notEqual(document.cookie.indexOf('SP_ID'), -1);
         });

--- a/test/spec/spid-cookie_test.js
+++ b/test/spec/spid-cookie_test.js
@@ -1,8 +1,8 @@
 describe('SPiD.Cookie', function() {
 
     var assert = chai.assert;
-    var setup = {client_id : '4d00e8d6bf92fc8648000000', server: 'stage.payment.schibsted.se', useSessionCluster:false, logging:false};
-    var setupProd = {client_id : '4d00e8d6bf92fc8648000000', server: 'payment.schibsted.se', logging:false, cookie: false, cache:false};
+    var setup = {client_id : '4d00e8d6bf92fc8648000000', server: 'stage.payment.schibsted.se', useSessionCluster:false, logging:false, setVarnishCookie: true};
+    var setupProd = {client_id : '4d00e8d6bf92fc8648000000', server: 'payment.schibsted.se', logging:false, cookie: false, cache:false, setVarnishCookie: true};
     var spidCookie = require('../../src/spid-cookie'),
         SPiD = require('../../src/spid-sdk');
 
@@ -44,7 +44,7 @@ describe('SPiD.Cookie', function() {
 
         it('SPiD.Cookie.setVarnishCookie should set varnish cookie', function() {
             var session = {user:123, sp_id: 123, expiresIn: 5000, baseDomain: cookieDomain};
-            spidCookie.setVarnishCookie(session, session.expiresIn);
+            spidCookie.tryVarnishCookie(session, session.expiresIn);
 
             assert.notEqual(document.cookie.indexOf('SP_ID'), -1);
         });

--- a/test/spec/spid-persist_test.js
+++ b/test/spec/spid-persist_test.js
@@ -5,6 +5,12 @@ describe('SPiD.Persist', function() {
     var SPiD  = require('../../src/spid-sdk'),
         persist = require('../../src/spid-persist');
 
+    var cookieDomain = (0 === window.location.host.indexOf('localhost:')) ? 'localhost' : window.location.host;
+
+    function clearVarnishCookie() {
+        document.cookie = 'SP_ID=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.' + cookieDomain;
+    }
+
     describe('SPiD no-storage setup', function() {
         it('SPiD.Persist default should have set/get/clear methods ', function() {
             SPiD.init(setup);
@@ -82,5 +88,99 @@ describe('SPiD.Persist', function() {
             assert.isTrue(methodSpy.called);
             assert.include(methodSpy.getCall(0).args[0], _setup.client_id, 'key should include client id');
         });
+    });
+
+
+    describe(' when varnish cookie option is set to true ', function() {
+
+        var _setup = setup;
+        beforeEach(function() {
+            _setup.setVarnishCookie = true;
+        });
+
+        afterEach(function() {
+            clearVarnishCookie();
+        });
+
+        it('should set varnish cookie even when local storage is used', function() {
+            _setup.storage = 'localstorage';
+            SPiD.init(_setup);
+
+            assert.equal(document.cookie.indexOf('SP_ID'), -1);
+            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
+            assert.notEqual(document.cookie.indexOf('SP_ID'), -1);
+        });
+
+        it('should set varnish cookie when cookies are used', function() {
+            _setup.storage = 'cookie';
+            SPiD.init(_setup);
+
+            assert.equal(document.cookie.indexOf('SP_ID'), -1);
+            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
+            assert.notEqual(document.cookie.indexOf('SP_ID'), -1);
+        });
+
+    });
+
+    describe(' when varnish cookie option is not set ', function() {
+
+        var _setup = setup;
+        beforeEach(function() {
+            delete _setup.setVarnishCookie;
+        });
+
+        afterEach(function() {
+            clearVarnishCookie();
+        });
+
+        it('should not set varnish cookie when local storage is used', function() {
+            _setup.storage = 'localstorage';
+            SPiD.init(_setup);
+
+            assert.equal(document.cookie.indexOf('SP_ID'), -1);
+            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
+            assert.equal(document.cookie.indexOf('SP_ID'), -1);
+        });
+
+        it('should set varnish cookie when cookies are used', function() {
+            _setup.storage = 'cookie';
+            SPiD.init(_setup);
+
+            assert.equal(document.cookie.indexOf('SP_ID'), -1);
+            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
+            assert.notEqual(document.cookie.indexOf('SP_ID'), -1);
+        });
+
+    });
+
+    describe(' when varnish cookie option is set to false ', function() {
+
+        var _setup = setup;
+        beforeEach(function() {
+            _setup.setVarnishCookie = false;
+        });
+
+        afterEach(function() {
+            clearVarnishCookie();
+        });
+
+        it('should not set varnish cookie when local storage is used', function() {
+            _setup.storage = 'localstorage';
+            SPiD.init(_setup);
+
+            assert.equal(document.cookie.indexOf('SP_ID'), -1);
+            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
+            assert.equal(document.cookie.indexOf('SP_ID'), -1);
+        });
+
+        it('should not set varnish cookie even when cookies are used', function() {
+            _setup.storage = 'cookie';
+            SPiD.init(_setup);
+
+            assert.equal(document.cookie.indexOf('SP_ID'), -1);
+            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
+            assert.equal(document.cookie.indexOf('SP_ID'), -1);
+        });
+
     });
 });

--- a/test/spec/spid-persist_test.js
+++ b/test/spec/spid-persist_test.js
@@ -5,12 +5,6 @@ describe('SPiD.Persist', function() {
     var SPiD  = require('../../src/spid-sdk'),
         persist = require('../../src/spid-persist');
 
-    var cookieDomain = (0 === window.location.host.indexOf('localhost:')) ? 'localhost' : window.location.host;
-
-    function clearVarnishCookie() {
-        document.cookie = 'SP_ID=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.' + cookieDomain;
-    }
-
     describe('SPiD no-storage setup', function() {
         it('SPiD.Persist default should have set/get/clear methods ', function() {
             SPiD.init(setup);
@@ -90,97 +84,4 @@ describe('SPiD.Persist', function() {
         });
     });
 
-
-    describe(' when varnish cookie option is set to true ', function() {
-
-        var _setup = setup;
-        beforeEach(function() {
-            _setup.setVarnishCookie = true;
-        });
-
-        afterEach(function() {
-            clearVarnishCookie();
-        });
-
-        it('should set varnish cookie even when local storage is used', function() {
-            _setup.storage = 'localstorage';
-            SPiD.init(_setup);
-
-            assert.equal(document.cookie.indexOf('SP_ID'), -1);
-            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
-            assert.notEqual(document.cookie.indexOf('SP_ID'), -1);
-        });
-
-        it('should set varnish cookie when cookies are used', function() {
-            _setup.storage = 'cookie';
-            SPiD.init(_setup);
-
-            assert.equal(document.cookie.indexOf('SP_ID'), -1);
-            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
-            assert.notEqual(document.cookie.indexOf('SP_ID'), -1);
-        });
-
-    });
-
-    describe(' when varnish cookie option is not set ', function() {
-
-        var _setup = setup;
-        beforeEach(function() {
-            delete _setup.setVarnishCookie;
-        });
-
-        afterEach(function() {
-            clearVarnishCookie();
-        });
-
-        it('should not set varnish cookie when local storage is used', function() {
-            _setup.storage = 'localstorage';
-            SPiD.init(_setup);
-
-            assert.equal(document.cookie.indexOf('SP_ID'), -1);
-            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
-            assert.equal(document.cookie.indexOf('SP_ID'), -1);
-        });
-
-        it('should set varnish cookie when cookies are used', function() {
-            _setup.storage = 'cookie';
-            SPiD.init(_setup);
-
-            assert.equal(document.cookie.indexOf('SP_ID'), -1);
-            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
-            assert.notEqual(document.cookie.indexOf('SP_ID'), -1);
-        });
-
-    });
-
-    describe(' when varnish cookie option is set to false ', function() {
-
-        var _setup = setup;
-        beforeEach(function() {
-            _setup.setVarnishCookie = false;
-        });
-
-        afterEach(function() {
-            clearVarnishCookie();
-        });
-
-        it('should not set varnish cookie when local storage is used', function() {
-            _setup.storage = 'localstorage';
-            SPiD.init(_setup);
-
-            assert.equal(document.cookie.indexOf('SP_ID'), -1);
-            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
-            assert.equal(document.cookie.indexOf('SP_ID'), -1);
-        });
-
-        it('should not set varnish cookie even when cookies are used', function() {
-            _setup.storage = 'cookie';
-            SPiD.init(_setup);
-
-            assert.equal(document.cookie.indexOf('SP_ID'), -1);
-            persist.set({sp_id: 12345, expiresIn: 5000, baseDomain: cookieDomain});
-            assert.equal(document.cookie.indexOf('SP_ID'), -1);
-        });
-
-    });
 });


### PR DESCRIPTION
Hi,

We need some control regarding Varnish cookie setup.
We'd like to use localStorage as persistence because passing additional 2.5k of cookie back and forth is bad for performance - but, at the same time, we need ```SP_ID``` cookie set for Varnish, as it can't reach into localStorage.

Currenly, setting Varnish cookie is only possible when using cookies as persistence module. This PR fixes that with new ```setVarnishCookie``` option, while keeping backwards compatibility (if user does not specify this option then SDK will behave as it used to).