### PR TITLE
Hardcoded 'response_type' to 'code' in SPiD_Uri.account()

### DIFF
--- a/src/spid-uri.js
+++ b/src/spid-uri.js
@@ -54,6 +54,7 @@ function logout(redirect_uri, client_id) {
 function account(redirect_uri, client_id) {
     var options = config.options();
     var params = {
+        'response_type': 'code',
         'client_id': client_id || options.client_id,
         'redirect_uri': _encode(redirect_uri)
     };

--- a/test/spec/spid-uri_test.js
+++ b/test/spec/spid-uri_test.js
@@ -76,15 +76,15 @@ describe('SPiD.Uri', function() {
     it('SPiD.Uri.account should return correctly formatted URL for account summary', function() {
         assert.equal(
             uri.account('http://random.com', '123' ),
-            uri.build('account/summary', {'client_id':'123','redirect_uri': encodeURIComponent('http://random.com') })
+            uri.build('account/summary', {'response_type':'code', 'client_id':'123','redirect_uri': encodeURIComponent('http://random.com') })
         );
         assert.equal(
             uri.account(null, '123'),
-            uri.build('account/summary', {'client_id':'123','redirect_uri': encodeURIComponent(window.location.toString()) })
+            uri.build('account/summary', {'response_type':'code', 'client_id':'123','redirect_uri': encodeURIComponent(window.location.toString()) })
         );
         assert.equal(
             uri.account(),
-            uri.build('account/summary', {'client_id':setup.client_id,'redirect_uri': encodeURIComponent(window.location.toString()) })
+            uri.build('account/summary', {'response_type':'code', 'client_id':setup.client_id,'redirect_uri': encodeURIComponent(window.location.toString()) })
         );
     });
 


### PR DESCRIPTION
When visiting the URL generated without this parameter set, SPiD will immediately throw you back with the error "invalid response type".