### PR TITLE
Id 764 add support for node v4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: node_js
 sudo: false
 node_js:
 - '0.10'
+- '0.12'
 - '4.4'
+- 'node'
 before_script: npm install -g grunt-cli
 before_deploy: grunt
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 sudo: false
 node_js:
 - '0.10'
+- '4.4'
 before_script: npm install -g grunt-cli
 before_deploy: grunt
 deploy:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Version](https://badge.fury.io/js/spid-sdk-js.svg)](http://badge.fury.io/js/spid-sdk-js) 
 [![Build Status](https://travis-ci.org/schibsted/sdk-js.svg?branch=master)](https://travis-ci.org/schibsted/sdk-js)
+[![Dependency Status](https://david-dm.org/schibsted/sdk-js.png)](https://david-dm.org/schibsted/sdk-js) 
+[![devDependency Status](https://david-dm.org/schibsted/sdk-js/dev-status.png)](https://david-dm.org/schibsted/sdk-js#info=devD)
 
 SDK to integrate to the SPiD frontend API.
 Used to check if user is logged in or not, or owns a product or not.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SPiD JS SDK
 
+[![Build Status](https://travis-ci.org/schibsted/sdk-js.svg?branch=master)](https://travis-ci.org/schibsted/sdk-js)
+
 SDK to integrate to the SPiD frontend API.
 Used to check if user is logged in or not, or owns a product or not.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SPiD JS SDK
 
-[![Build Status](https://travis-ci.org/schibsted/sdk-js.svg?branch=master)](https://travis-ci.org/schibsted/sdk-js)
+[![NPM](https://nodei.co/npm/aws-sdk.svg?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/aws-sdk/)
+[![Version](https://badge.fury.io/js/spid-sdk-js.svg)](http://badge.fury.io/js/spid-sdk-js) [![Build Status](https://travis-ci.org/schibsted/sdk-js.svg?branch=master)](https://travis-ci.org/schibsted/sdk-js)
 
 SDK to integrate to the SPiD frontend API.
 Used to check if user is logged in or not, or owns a product or not.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SPiD JS SDK
 
-[![NPM](https://nodei.co/npm/aws-sdk.svg?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/aws-sdk/)
+[![NPM](https://nodei.co/npm/spid-sdk-js.svg?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/spid-sdk-js/)
 
 [![Version](https://badge.fury.io/js/spid-sdk-js.svg)](http://badge.fury.io/js/spid-sdk-js) 
 [![Build Status](https://travis-ci.org/schibsted/sdk-js.svg?branch=master)](https://travis-ci.org/schibsted/sdk-js)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # SPiD JS SDK
 
 [![NPM](https://nodei.co/npm/aws-sdk.svg?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/aws-sdk/)
-[![Version](https://badge.fury.io/js/spid-sdk-js.svg)](http://badge.fury.io/js/spid-sdk-js) [![Build Status](https://travis-ci.org/schibsted/sdk-js.svg?branch=master)](https://travis-ci.org/schibsted/sdk-js)
+
+[![Version](https://badge.fury.io/js/spid-sdk-js.svg)](http://badge.fury.io/js/spid-sdk-js) 
+[![Build Status](https://travis-ci.org/schibsted/sdk-js.svg?branch=master)](https://travis-ci.org/schibsted/sdk-js)
 
 SDK to integrate to the SPiD frontend API.
 Used to check if user is logged in or not, or owns a product or not.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Version](https://badge.fury.io/js/spid-sdk-js.svg)](http://badge.fury.io/js/spid-sdk-js) 
 [![Build Status](https://travis-ci.org/schibsted/sdk-js.svg?branch=master)](https://travis-ci.org/schibsted/sdk-js)
 [![Dependency Status](https://david-dm.org/schibsted/sdk-js.png)](https://david-dm.org/schibsted/sdk-js) 
-[![devDependency Status](https://david-dm.org/schibsted/sdk-js/dev-status.png)](https://david-dm.org/schibsted/sdk-js#info=devD)
+[![devDependency Status](https://david-dm.org/schibsted/sdk-js/dev-status.png)](https://david-dm.org/schibsted/sdk-js#info=devDependencies&view=table)
 
 SDK to integrate to the SPiD frontend API.
 Used to check if user is logged in or not, or owns a product or not.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "karma-sinon-chai": "~1.1",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.4",
-    "phantomjs": "^1.9.18",
+    "phantomjs-prebuilt": "^2.1.7",
     "webpack": "^1.12.6",
     "webpack-dev-server": "^1.12.1"
   },


### PR DESCRIPTION
- Added v0.12, v4.4 and latest to travis build
- Added badges to the README for easy overlook over latest release, dependencies and build status
- Changed phantomjs to phantomjs-prebuilt in package.js due to phantomsj being deprecated in favor for phantomjs-prebuilt