### PR TITLE
do not set session data prematurely

### DIFF
--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -57,7 +57,6 @@ function hasSession(callback) {
 
     var data = persist.get();
     if(data) {
-        _session = data;
         return respond(null, data);
     }
 


### PR DESCRIPTION
Discovered upon problems with SPiD.login event not being fired upon page load, when user is already logged in (according to http://techdocs.spid.no/sdks/js/events/ -> SPiD.login: Page loads, user is already logged in). This PR fixes that.

Explanation:
If ```_session = data;``` is called right before ```respond``` then effectively previous and current sessions become the same:

spid-sdk.js, hasSession excerpts
```javascript
var data = persist.get();
if(data) {
    _session = data;
    return respond(null, data);
}

//_session = data was called before respond, data refers to the same object as _session here
respond = function(err, data) {
    eventTrigger.session(_session, data); // this receives two references to same object
     _session = data; // duplicate assignment, this is the only one that should be called
     callback(err, data);
}
```