### PR TITLE
ensure async api

### DIFF
--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -32,11 +32,11 @@ function hasSession(callback) {
     callback = callback || function() {
         };
     var that = this,
-        respond = function(err, data) {
+        respond = util.makeAsync(function(err, data) {
             eventTrigger.session(_session, data);
             _session = data;
             callback(err, data);
-        },
+        }),
         handleResponse = function(err, data) {
             if(!err && !!data.result) {
                 persist.set(data, data.expiresIn);
@@ -64,8 +64,8 @@ function hasSession(callback) {
 }
 
 function hasProduct(productId, callback) {
-    callback = callback || function() {
-        };
+    callback = util.makeAsync(callback || function() {
+        });
     if(cache.enabled()) {
         var cacheVal = cache.get('prd_{id}'.replace('{id}', productId));
         if(cacheVal && (cacheVal.refreshed + config.options().refresh_timeout) > util.now()) {
@@ -89,8 +89,8 @@ function hasProduct(productId, callback) {
 }
 
 function hasSubscription(productId, callback) {
-    callback = callback || function() {
-        };
+    callback = util.makeAsync(callback || function() {
+        });
     if(cache.enabled()) {
         var cacheVal = cache.get('sub_{id}'.replace('{id}', productId));
         if(cacheVal && (cacheVal.refreshed + config.options().refresh_timeout) > util.now()) {
@@ -151,12 +151,12 @@ function acceptAgreement(callback) {
 }
 
 //Async loader
-window.setTimeout(function() {
+util.makeAsync(function() {
     if(typeof (window.asyncSPiD) === 'function' && !window.asyncSPiD.hasRun) {
         window.asyncSPiD();
         window.asyncSPiD.hasRun = true;
     }
-}, 0);
+})();
 
 module.exports = {
     version: function() {

--- a/src/spid-util.js
+++ b/src/spid-util.js
@@ -25,8 +25,18 @@ function buildUri(server, path, params) {
     return url;
 }
 
+function makeAsync(fn) {
+    return function() {
+        var args = arguments;
+        setTimeout(function() {
+            fn.apply(null, args);
+        }, 0);
+    };
+}
+
 module.exports = {
     copy: copy,
     now: now,
-    buildUri: buildUri
+    buildUri: buildUri,
+    makeAsync: makeAsync
 };

--- a/test/spec/spid-util_test.js
+++ b/test/spec/spid-util_test.js
@@ -9,6 +9,18 @@ describe('SPiD.Util', function() {
         SPiD.init(setup);
     });
 
+    it('SPiD.Util.makeAsync should return wrapped asynchronous function', function(done) {
+        var called = false;
+        util.makeAsync(function() {
+            called = true;
+        })();
+        assert.equal(called, false);
+        setTimeout(function() {
+            assert.equal(called, true);
+            done();
+        }, 1);
+    });
+
     it('SPiD.Util.buildUri should return correctly formatted URL', function() {
         assert.equal(util.buildUri('https://google.se/', 'test', {a:1,b:2,c:null}), 'https://google.se/test?a=1&b=2');
         assert.equal(util.buildUri('https://google.se/', null, {a:1,b:2,c:null}), 'https://google.se/?a=1&b=2');


### PR DESCRIPTION
There's no way to tell if events/callbacks are going to be fired synchronously or asynchronously. This problem is rather hard to spot and has bitten us already, so I think would be a good thing to pull in.

Take `hasSession` as an example: https://github.com/schibsted/sdk-js/blob/8c9afd0439bdd056bad9ec2d151e0e93468a6ebc/src/spid-sdk.js#L31
and such code:
```javascript
var currentSession;
SPiD.hasSession(123);
SPiD.event.subscribe('SPiD.sessionChange', function(data) {
    currentSession = data;
});
```

If cache is empty everything is ok, event gets fired subsequently.
If however cache is populated, hasSession triggers events right away, so event handler is attached later and never fires.
This PR fixes that by wrapping SDK functions to ensure that they're always called asynchronously.

I think cache is an implementation detail and it shouldn't change client-facing behavior of the SDK :)

@thogra @linnhege @joawan