### PR TITLE
ensure update of varnish cookie even if session is cached

### DIFF
--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -33,6 +33,9 @@ function hasSession(callback) {
         };
     var that = this,
         respond = util.makeAsync(function(err, data) {
+            if(!err && !!data.result) {
+                cookie.tryVarnishCookie(data);
+            }
             eventTrigger.session(_session, data);
             _session = data;
             callback(err, data);
@@ -40,7 +43,6 @@ function hasSession(callback) {
         handleResponse = function(err, data) {
             if(!err && !!data.result) {
                 persist.set(data, data.expiresIn);
-                cookie.tryVarnishCookie(data);
             }
             respond(err, data);
         },

--- a/test/spec/spid-sdk_test.js
+++ b/test/spec/spid-sdk_test.js
@@ -320,6 +320,31 @@ describe('SPiD', function() {
                 done();
             });
         });
+
+        it('SPiD.hasSession should update SP_ID cookie when data comes from persistence', function(done) {
+            var _setup = setup();
+            _setup.setVarnishCookie = true;
+            _setup.storage = 'localstorage';
+            SPiD.init(_setup);
+
+            var storedSession = {
+                'result':true,
+                'expiresIn':7111,
+                'baseDomain':cookieDomain,
+                'userStatus':'connected',
+                'userId':1844813,
+                'sp_id':'4f1e2ae59caf7c2f4a058b76'
+            };
+
+            persistGetStub.onFirstCall().returns(storedSession);
+            SPiD.hasSession(function(err, res) {
+                if(!err && res.result && res.userId === 1844813) {
+                    assert.notEqual(document.cookie.indexOf('SP_ID'), -1);
+                    done();
+                }
+            });
+            assert.isFalse(talkRequestStub.called);
+        });
     });
 
     describe('SPiD.acceptAgreement', function() {


### PR DESCRIPTION
Case: cookie has expired / was deleted, but session is still kept in persistence layer - then cookie state should be synced with persistence state.