### PR TITLE
Expose method to check Varnish cookie

### DIFF
--- a/src/spid-cookie.js
+++ b/src/spid-cookie.js
@@ -44,6 +44,10 @@ function clearVarnishCookie() {
     _setRaw(_varnishCookieName, '', 0, _domain);
 }
 
+function hasVarnishCookie() {
+    return document.cookie.indexOf(_varnishCookieName + '=') > -1;
+}
+
 function set(name, session, expiresInSeconds) {
     if(!session) { return false; }
     _domain = session.baseDomain;
@@ -82,6 +86,7 @@ module.exports = {
     set: set,
     tryVarnishCookie: tryVarnishCookie,
     clearVarnishCookie: clearVarnishCookie,
+    hasVarnishCookie: hasVarnishCookie,
     get: get,
     clear: clear,
     name: name

--- a/src/spid-sdk.js
+++ b/src/spid-sdk.js
@@ -188,6 +188,9 @@ module.exports = {
     coreEndpoint: function() {
         return (config.options().https ? 'https' : 'http') + '://' + config.options().server + '/ajax/hasSession.js';
     },
+    hasVarnishCookie: function() {
+        return cookie.hasVarnishCookie();
+    },
     acceptAgreement: acceptAgreement,
     event: spidEvent,
     sessionCache: persist,

--- a/test/spec/spid-cookie_test.js
+++ b/test/spec/spid-cookie_test.js
@@ -63,6 +63,20 @@ describe('SPiD.Cookie', function() {
             assert.equal(document.cookie.indexOf('SP_ID'), -1);
         });
 
+        it('SPiD.Cookie.hasVarnishCookie should check if varnish cookie exists', function() {
+            var session = {user:123, sp_id: 123, expiresIn: 5000, baseDomain: cookieDomain};
+            spidCookie.tryVarnishCookie(session, session.expiresIn);
+
+            assert.equal(spidCookie.hasVarnishCookie(), true);
+        });
+
+        it('SPiD.Cookie.hasVarnishCookie should return false after cookie clearing', function() {
+            document.cookie = 'SP_ID=123; domain=' + cookieDomain;
+            spidCookie.clearVarnishCookie();
+
+            assert.equal(spidCookie.hasVarnishCookie(), false);
+        });
+
         it('SPiD.Cookie.get should return session', function() {
             var session = {user:123, sp_id: 123, expiresIn: 5000, baseDomain: cookieDomain};
             spidCookie.set('name', session, session.expiresIn);


### PR DESCRIPTION
This is a part that commonly repeats across different client integrations, so it would be good to have it pulled back to the SDK.
Having `document.cookie.indexOf('SP_ID') > -1` in integration feels hacky because `SP_ID` is internal implementation detail that's not exposed by the SDK.