### PR TITLE
Add init logic to Uri module so that it is consistent with sdk

### DIFF
--- a/src/spid-uri.js
+++ b/src/spid-uri.js
@@ -7,6 +7,10 @@ function _encode(redirect_uri) {
     return encodeURIComponent(redirect_uri || window.location.toString());
 }
 
+function globalExport(global) {
+    global.SPiD_Uri = global.SPiD_Uri || this;
+}
+
 function build(path, params) {
     return util.buildUri(config.server(), path, params);
 }
@@ -127,6 +131,10 @@ function purchaseCampaign(campaign_id, product_id, voucher_code, redirect_uri, c
 module.exports = {
     init: function(opts) {
         config.init(opts);
+
+        if(!config.options().noGlobalExport) {
+            globalExport.call(this, window);
+        }
     },
     build: build,
     login: login,

--- a/test/spec/spid-uri_test.js
+++ b/test/spec/spid-uri_test.js
@@ -9,6 +9,18 @@ describe('SPiD.Uri', function() {
         SPiD.init(setup);
     });
 
+    it('SPiD.Uri.init should expose SPiD_Uri to global', function() {
+        uri.init(setup);
+        assert.equal(window.SPiD_Uri, uri);
+        delete window.SPiD_Uri;
+    });
+
+    it('SPiD.Uri.init should NOT expose SPiD_Uri to global when configured so', function() {
+        uri.init({ client_id : '4d00e8d6bf92fc8648000000', server: 'stage.payment.schibsted.se', useSessionCluster:false, logging:false, noGlobalExport: true });
+        assert.equal(window.SPiD_Uri, undefined);
+        delete window.SPiD_Uri;
+    });
+
     it('SPiD.Uri.build should return correctly formatted URL', function() {
         assert.equal(uri.build('test', {a:1,b:2,c:null}), 'https://' + setup.server + '/test?a=1&b=2');
     });


### PR DESCRIPTION
When using the SDK as an import from the `npm` package one would expect `SPiD` and `SPiD_Uri` to both behave similar given the same configuration to `init`. Both expose a public API, and it makes sense that both consistently can be reached through `window` after running `init`.